### PR TITLE
Fix entity removal script link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ However, we understand that the Rasa community is a global one, and in the long-
 
 We would like to make the training data as easy as possible to adopt to new training models and annotating entities highly dependent on your bot’s purpose. Therefore, we will first focus on collecting training data that only includes intents.
 
-To help you remove the annotated entities from your training data, you can run [this script](https://github.com/RasaHQ/NLU-training-data/blob/master/entity-removal-script). 
+To help you remove the annotated entities from your training data, you can run [this script](https://github.com/RasaHQ/NLU-training-data/blob/master/entity-removal-script.py). 
 
 ---  
 

--- a/how-to-remove-entities/README.md
+++ b/how-to-remove-entities/README.md
@@ -6,7 +6,7 @@ We would like to make the training data as easy as possible to adopt to new trai
 
 1. Make sure your training data is backed up! 
 
-2. Open the command line, and use [this simple Python script](https://github.com/RasaHQ/NLU-training-data/blob/master/how-to-remove-entities/entity-remove-script) that replaces all the entity annotations with the plain text.
+2. Open the command line, and use [this simple Python script](https://github.com/RasaHQ/NLU-training-data/blob/master/how-to-remove-entities/entity-remove-script.py) that replaces all the entity annotations with the plain text.
 
 3. Prepare to donate your training data by following these [guidelines.](https://github.com/RasaHQ/NLU-training-data#how-do-i-donate-my-training-data) 
 


### PR DESCRIPTION
The link to the entity removal script is missing a ".py" at the end, hence resulting in a 404 error.